### PR TITLE
Fix a few binding issues.

### DIFF
--- a/BrightcoveSDK.tvOS/ApiDefinition.cs
+++ b/BrightcoveSDK.tvOS/ApiDefinition.cs
@@ -2224,6 +2224,8 @@ namespace BrightcoveSDK.tvOS
         void EncryptedContentKeyForContentKeyIdentifier(string contentKeyIdentifier, NSData keyRequest, BCOVSource source, [NullAllowed] NSDictionary options, Action<NSUrlResponse, NSData, NSError> completionHandler);
     }
 
+    interface IBCOVFPSAuthorizationProxy { }
+
     // @interface BCOVFPSAdditions (BCOVPlayerSDKManager)
     //[Category]
     //[BaseType(typeof(BCOVPlayerSDKManager))]
@@ -2233,19 +2235,19 @@ namespace BrightcoveSDK.tvOS
     {
         // -(id<BCOVPlaybackController> _Nonnull)createFairPlayPlaybackControllerWithAuthorizationProxy:(id<BCOVFPSAuthorizationProxy> _Nonnull)proxy;
         [Export("createFairPlayPlaybackControllerWithAuthorizationProxy:")]
-        BCOVPlaybackController CreateFairPlayPlaybackControllerWithAuthorizationProxy(BCOVFPSAuthorizationProxy proxy);
+        BCOVPlaybackController CreateFairPlayPlaybackControllerWithAuthorizationProxy(IBCOVFPSAuthorizationProxy proxy);
 
         // -(id<BCOVPlaybackSessionProvider> _Nonnull)createFairPlaySessionProviderWithAuthorizationProxy:(id<BCOVFPSAuthorizationProxy> _Nonnull)proxy upstreamSessionProvider:(id<BCOVPlaybackSessionProvider> _Nullable)provider;
         [Export("createFairPlaySessionProviderWithAuthorizationProxy:upstreamSessionProvider:")]
-        BCOVPlaybackSessionProvider CreateFairPlaySessionProviderWithAuthorizationProxy(BCOVFPSAuthorizationProxy proxy, [NullAllowed] BCOVPlaybackSessionProvider provider);
+        BCOVPlaybackSessionProvider CreateFairPlaySessionProviderWithAuthorizationProxy(IBCOVFPSAuthorizationProxy proxy, [NullAllowed] BCOVPlaybackSessionProvider provider);
 
         // -(id<BCOVPlaybackController> _Nonnull)createFairPlayPlaybackControllerWithApplicationCertificate:(NSData * _Nullable)appCert authorizationProxy:(id<BCOVFPSAuthorizationProxy> _Nonnull)proxy viewStrategy:(BCOVPlaybackControllerViewStrategy _Nullable)viewStrategy;
         [Export("createFairPlayPlaybackControllerWithApplicationCertificate:authorizationProxy:viewStrategy:")]
-        BCOVPlaybackController CreateFairPlayPlaybackControllerWithApplicationCertificate([NullAllowed] NSData appCert, BCOVFPSAuthorizationProxy proxy, [NullAllowed] BCOVPlaybackControllerViewStrategy viewStrategy);
+        BCOVPlaybackController CreateFairPlayPlaybackControllerWithApplicationCertificate([NullAllowed] NSData appCert, IBCOVFPSAuthorizationProxy proxy, [NullAllowed] BCOVPlaybackControllerViewStrategy viewStrategy);
 
         // -(id<BCOVPlaybackSessionProvider> _Nonnull)createFairPlaySessionProviderWithApplicationCertificate:(NSData * _Nullable)appCert authorizationProxy:(id<BCOVFPSAuthorizationProxy> _Nonnull)proxy upstreamSessionProvider:(id<BCOVPlaybackSessionProvider> _Nullable)provider;
         [Export("createFairPlaySessionProviderWithApplicationCertificate:authorizationProxy:upstreamSessionProvider:")]
-        BCOVPlaybackSessionProvider CreateFairPlaySessionProviderWithApplicationCertificate([NullAllowed] NSData appCert, BCOVFPSAuthorizationProxy proxy, [NullAllowed] BCOVPlaybackSessionProvider provider);
+        BCOVPlaybackSessionProvider CreateFairPlaySessionProviderWithApplicationCertificate([NullAllowed] NSData appCert, IBCOVFPSAuthorizationProxy proxy, [NullAllowed] BCOVPlaybackSessionProvider provider);
     }
 
     //[Static]
@@ -2278,9 +2280,9 @@ namespace BrightcoveSDK.tvOS
     }
 
     // @interface BCOVFPSBrightcoveAuthProxy : NSObject <BCOVFPSAutorizationProxy>
-    [Protocol, Model]
-    [BaseType(typeof(BCOVFPSAuthorizationProxy))]
-    interface BCOVFPSBrightcoveAuthProxy
+    [BaseType(typeof(NSObject))]
+    [DisableDefaultCtor]
+    interface BCOVFPSBrightcoveAuthProxy : BCOVFPSAuthorizationProxy
     {
         // @property (nonatomic, strong) NSURL * _Null_unspecified fpsBaseURL;
         [Export("fpsBaseURL", ArgumentSemantic.Strong)]

--- a/Sample.Brightcove.tvOS/TvViewController.cs
+++ b/Sample.Brightcove.tvOS/TvViewController.cs
@@ -38,7 +38,7 @@ namespace Sample.Brightcove.tvOS
             base.ViewDidLoad();
 
 
-            var fairPlayAuthProxy = new BCOVFPSBrightcoveAuthProxy();
+            var fairPlayAuthProxy = new BCOVFPSBrightcoveAuthProxy (null, null);
 
             // Create chain of session providers
             // And upstream session provider to link to. If nil, a BCOVBasicSessionProvider will be used.


### PR DESCRIPTION
To use protocols in API (as parameters or return values), declare an empty
interface with the same name as the protocol prefixed with 'I'
(IBCOVFPSAuthorizationProxy for the BCOVFPSAuthorizationProxy protocol in this
case), and then use the I-prefixed typename as the parameter/return type.

BCOVFPSBrightcoveAuthProxy is not a protocol, it's a class, so remove the
[Protocol, Model] attributes. It also doesn't have a default init selector, so
add the [DisableDefaultCtor] attribute.